### PR TITLE
canvas 0.2.0

### DIFF
--- a/src/CV.hpp
+++ b/src/CV.hpp
@@ -12,7 +12,7 @@
 
     #define __CV_NUMBER_NATIVE_TYPE double
 
-    static const __CV_NUMBER_NATIVE_TYPE CANVAS_LANG_VERSION[3] = { 0, 1, 0 }; // BETA
+    static const __CV_NUMBER_NATIVE_TYPE CANVAS_LANG_VERSION[3] = { 0, 2, 0 }; // BETA
 
     namespace CV {
 
@@ -688,6 +688,8 @@
             // For helping the stack finding items (existing or not existing ones)
             std::shared_ptr<CV::DisplayItem> addDisplayItem(const std::string &name, std::shared_ptr<CV::DisplayItem> &ditem);
             std::shared_ptr<CV::DisplayItem> addDisplayItem(const std::string &name, unsigned insId, unsigned origin = 0); // generic
+            std::shared_ptr<CV::DisplayItem> addDisplayItemTyped(const std::string &name, unsigned insId, std::shared_ptr<CV::Item> &item);
+            std::shared_ptr<CV::DisplayItem> addDisplayItemTyped(const std::string &name, unsigned insId, unsigned type);
             std::shared_ptr<CV::DisplayItem> addDisplayItemFunction(const std::string &name, unsigned insId, unsigned argN, unsigned origin = 0);
             bool removeDisplayItem(unsigned id); // by insId
             void flushDisplayItems();

--- a/test.py
+++ b/test.py
@@ -73,14 +73,24 @@ cases = [
     TestCase("gte 8 8 5", "1", True),
     TestCase("eq 5.2 1.2", "0", True),
 
-    # Copy trait
-    TestCase("proxy l-sort", "[fn [c l] [BINARY]]", True),
+    # test ref
+    TestCase("ref l-sort", "[fn [c l] [BINARY]]", True),
 
     # with / untether
     TestCase("[with [untether [+ [l-gen 1 1000]^]] [+ 1 inherited]]|await", "500501", True), 
     
     # with / async
-    TestCase("[with [with [async [+ 0 1]] [+ inherited 1]] [+ inherited 1]]|await", "3", True)    
+    TestCase("[with [with [async [+ 0 1]] [+ inherited 1]] [+ inherited 1]]|await", "3", True),
+
+    # Function passing
+    TestCase("[set test [fn [t][t 1 1 1]]][test +]", "3", True),
+
+    # Function from context passing
+    TestCase("[set test [fn [t][t 1 1 1]]][test math:sin]", "[0.84147098 0.84147098 0.84147098]", True),      
+
+
+    # Function passing to binary functions
+    TestCase("l-filter [fn [n][math:mod n 2]] [l-gen 1 10]", "[2 4 6 8 10]", True)      
 ]
 
 print("ABOUT TO START TEST CASES FOR CANVAS")


### PR DESCRIPTION
This is a minor release, making some basic changes (some API changes, but since we're in beta,...), but more importantly fixed a major problem with regards to function passing as parameters. The issue? it didn't really work at all. This should address it, albeit with some performance imperfections.

**Changes:**
- Changed constructor `proxy` to `ref` to make it friendlier to people that don't know canvas internals (basically, references are called "proxies" internally). Will update documentation in the future to properly explain it all.
- Added the ability to pass functions as parameters.
- Function passing works a bit different when it's passed to a binary function. I scrapped together a quick solution that's just too slow. But it'll do for now. The problem is that binary functions are executed in an isolated environment, and it's post-compilation, so the compiler doesn't really know anything about the function (the binary one), and thus can't optimize. It's a fundamental flaw that arose in the transition from the literal interpreter to this psudo-compiled one.
- Added specific DisplayItem with the Typed characteristic, to help the compiler finding and plugging stuff.
- Fixed the `is-even` trait that had the wrong name
- Fixed some error messages
- Update tests accordingly

Nothing major in this release otherwise. I don't have yet a roadmap for future changes and feature additions. But as I adapt it to [CR](https://github.com/italrr/cr), more should arrive. With regards to the official 1.0 re-release, I think the more I stress it, the sooner. I want to make sure it's all fully function, at least the basics, before I re-release it.