### PR TITLE
canvas 0.2.2

### DIFF
--- a/src/CV.hpp
+++ b/src/CV.hpp
@@ -12,7 +12,7 @@
 
     #define __CV_NUMBER_NATIVE_TYPE double
 
-    static const __CV_NUMBER_NATIVE_TYPE CANVAS_LANG_VERSION[3] = { 0, 2, 1 }; // BETA
+    static const __CV_NUMBER_NATIVE_TYPE CANVAS_LANG_VERSION[3] = { 0, 2, 2 }; // BETA
 
     namespace CV {
 
@@ -699,7 +699,8 @@
 
             std::unordered_map<std::string, std::shared_ptr<CV::Item>> vars;
             std::shared_ptr<Context> upper;
-            std::shared_ptr<Context> top;
+
+            std::shared_ptr<Context> getTop();
             bool temporary;
             bool readOnly;
             uint64_t createdAt;
@@ -730,7 +731,6 @@
 
             std::shared_ptr<CV::Item> copy(bool deep = true);
 
-            void setTop(std::shared_ptr<Context> &nctx);
             ItemContextPair getWithContext(const std::string &name);
             ItemContextPair getWithContext(std::shared_ptr<CV::Item> &item);
             std::shared_ptr<CV::Item> set(const std::string &name, const std::shared_ptr<CV::Item> &item);
@@ -935,7 +935,7 @@
         std::string getPrompt();
 
         std::shared_ptr<CV::Item> interpret(const std::string &input, std::shared_ptr<CV::Context> &ctx, std::shared_ptr<CV::Cursor> &cursor, bool flushTemps = true);
-        void runFile(const std::string &path, std::shared_ptr<CV::Context> &ctx, std::shared_ptr<CV::Cursor> &cursor, bool relaxed);
+        void runFile(const std::string &path, std::shared_ptr<CV::Context> &ctx, std::shared_ptr<CV::Cursor> &cursor, bool relaxed, bool resetCtx = true);
         void flushContextTemps(std::shared_ptr<CV::Context> &ctx);
 
 

--- a/src/Interpreter.cpp
+++ b/src/Interpreter.cpp
@@ -146,7 +146,6 @@ int main(int argc, char* argv[]){
 	}
 	CV::setUseColor(dashC->valid);	
 	ctx->copyable = false;
-	ctx->setTop(ctx);
 
 	if(dashFile.get() && dashFile->valid){
 		if(dashRepl.get() && dashRepl->valid){


### PR DESCRIPTION
Another minor release addressing a thread lock misfortune from last release earlier today.  Also changed runFile to add "resetCtx", in case one one's to run a script without resetting the current Context (making it accumulative). 